### PR TITLE
Batteryflow

### DIFF
--- a/homeassistant/components/v2g_liberty/config_flow.py
+++ b/homeassistant/components/v2g_liberty/config_flow.py
@@ -13,10 +13,7 @@ from homeassistant.exceptions import HomeAssistantError
 import homeassistant.helpers.config_validation as cv
 
 
-from .const import (
-    DOMAIN,
-    DEFAULT_PORT,
-)
+from .const import DOMAIN, DEFAULT_PORT, DEFAULT_BATTERYLOW, DEFAULT_BATTERYHIGH
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -24,6 +21,17 @@ STEP_SETUP_DATA_SCHEMA = vol.Schema(
     {
         vol.Required("host"): str,
         vol.Required("port", default=DEFAULT_PORT): int,
+    }
+)
+
+STEP_BATTERYLOW_DATA_SCHEMA = vol.Schema(
+    {
+        vol.Required("battlow", default=DEFAULT_BATTERYLOW): int,
+    }
+)
+STEP_BATTERYHIGH_DATA_SCHEMA = vol.Schema(
+    {
+        vol.Required("battlow", default=DEFAULT_BATTERYHIGH): int,
     }
 )
 
@@ -101,6 +109,26 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
         return self.async_show_form(
             step_id="setup", data_schema=STEP_SETUP_DATA_SCHEMA, errors=errors
+        )
+
+    async def async_step_batterylow(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Handle the setup step."""
+        errors: dict[str, str] = {}
+        if user_input is not None:
+            try:
+                info = await validate_input(self.hass, user_input)
+            except CannotConnect:
+                errors["base"] = "cannot_connect"
+            except Exception:  # pylint: disable=broad-except
+                _LOGGER.exception("Unexpected exception")
+                errors["base"] = "unknown"
+            else:
+                return self.async_create_entry(title=info["title"], data=user_input)
+
+        return self.async_show_form(
+            step_id="battlow", data_schema=STEP_BATTERYLOW_DATA_SCHEMA, errors=errors
         )
 
 

--- a/homeassistant/components/v2g_liberty/config_flow.py
+++ b/homeassistant/components/v2g_liberty/config_flow.py
@@ -13,7 +13,7 @@ from homeassistant.exceptions import HomeAssistantError
 import homeassistant.helpers.config_validation as cv
 
 
-from .const import DOMAIN, DEFAULT_PORT, DEFAULT_BATTERYLOW, DEFAULT_BATTERYHIGH
+from .const import *
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -129,7 +129,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 vol.Range(min=10, max=30)(user_input["battlow"])
                 return await self.async_step_batthigh()
             except vol.Invalid:
-                errors = {"base": "outofscope"}
+                errors = {"base": "outofrange"}
 
         return self.async_show_form(
             step_id="battlow",
@@ -148,7 +148,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 vol.Range(min=60, max=100)(user_input["batthigh"])
                 return await self.async_step_battcap()
             except vol.Invalid:
-                errors = {"base": "outofscope"}
+                errors = {"base": "outofrange"}
 
         return self.async_show_form(
             step_id="batthigh",
@@ -160,14 +160,14 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     async def async_step_battcap(
         self, user_input: dict[str, Any] | None = None
     ) -> FlowResult:
-        """Handle the maximum battery % step."""
+        """Handle the battery capacity step."""
         errors: dict[str, str] = {}
         if user_input is not None:
             try:
                 vol.Range(min=10, max=150)(user_input["battcap"])
                 return await self.async_step_battcap()
             except vol.Invalid:
-                errors = {"base": "outofscope"}
+                errors = {"base": "outofrange"}
 
         return self.async_show_form(
             step_id="battcap",

--- a/homeassistant/components/v2g_liberty/config_flow.py
+++ b/homeassistant/components/v2g_liberty/config_flow.py
@@ -34,6 +34,11 @@ STEP_BATTERYHIGH_DATA_SCHEMA = vol.Schema(
         vol.Required("batthigh", default=DEFAULT_BATTERYHIGH): int,
     }
 )
+STEP_BATTERYCAP_DATA_SCHEMA = vol.Schema(
+    {
+        vol.Required("battcap"): int,
+    }
+)
 
 
 class PlaceholderHub:
@@ -141,7 +146,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         if user_input is not None:
             try:
                 vol.Range(min=60, max=100)(user_input["batthigh"])
-                return await self.async_step_batthigh()
+                return await self.async_step_battcap()
             except vol.Invalid:
                 errors = {"base": "outofscope"}
 
@@ -150,6 +155,26 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             data_schema=STEP_BATTERYHIGH_DATA_SCHEMA,
             errors=errors,
             last_step=False,
+        )
+
+    async def async_step_battcap(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Handle the maximum battery % step."""
+        errors: dict[str, str] = {}
+        if user_input is not None:
+            try:
+                vol.Range(min=10, max=150)(user_input["battcap"])
+                return await self.async_step_battcap()
+            except vol.Invalid:
+                errors = {"base": "outofscope"}
+
+        return self.async_show_form(
+            step_id="battcap",
+            data_schema=STEP_BATTERYCAP_DATA_SCHEMA,
+            errors=errors,
+            last_step=False,
+            description_placeholders={"ev_database_url": "https://ev-database.org"},
         )
 
 

--- a/homeassistant/components/v2g_liberty/const.py
+++ b/homeassistant/components/v2g_liberty/const.py
@@ -1,4 +1,7 @@
 """Constants for the V2G Liberty integration."""
 
 DOMAIN = "v2g_liberty"
+
 DEFAULT_PORT = 502
+DEFAULT_BATTERYLOW = 20
+DEFAULT_BATTERYHIGH = 80

--- a/homeassistant/components/v2g_liberty/strings.json
+++ b/homeassistant/components/v2g_liberty/strings.json
@@ -13,12 +13,25 @@
           "host": "Host address",
           "port": "Port number"
         }
+      },
+      "batterylow": {
+        "description": "Enter the Host and Port number for your charger.",
+        "data": {
+          "battlow": "Host address"
+        }
+      },
+      "batteryhigh": {
+        "description": "Enter the Host and Port number for your charger.",
+        "data": {
+          "batthigh": "Host address"
+        }
       }
     },
     "error": {
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
       "invalid_charger": "Invalid chager found",
-      "unknown": "[%key:common::config_flow::error::unknown%]"
+      "unknown": "[%key:common::config_flow::error::unknown%]",
+      "outofscope": "Your number is out of scope."
     },
     "abort": {
       "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"

--- a/homeassistant/components/v2g_liberty/strings.json
+++ b/homeassistant/components/v2g_liberty/strings.json
@@ -37,12 +37,9 @@
       },
       "battcap": {
         "title": "Usable capacity for car battery",
-        "description": "This is the the maximum energy storage capacity of the car's battery that can be used for driving/charging/discharging. This often is lower than the advertised capacity. \n Find a reliable value on ↗ [EV Database]({ev_database_url}). \n\n **Battery health** \n If a battery get's older it usually degrades and cannot contain as much energy as when it was new. It's advised to take this into account here. Do this by looking for the State of Health (SoH) in the cars the menu's. \n *E.g:* \n The SoH is 11/12 and the original usable capacity was 56kWh use a value of 51kWh.",
+        "description": "This is the the maximum energy storage capacity of the car's battery that can be used for driving/charging/discharging. This often is lower than the advertised capacity. \n Find a reliable value on ↗ [EV Database]({ev_database_url}). \n\n **Battery health** \n If a battery get's older it usually degrades and cannot contain as much energy as when it was new. It's advised to take this into account here. Do this by looking for the State of Health (SoH) in the car's menus. \n *E.G.:* \n The SoH is 11/12 and the original usable capacity was 56kWh use a value of 51kWh.",
         "data": {
           "battcap": "Usable capacity"
-        },
-        "data_description":{
-          "battcap": "Range between 60% and 100%. Some cars will never charge above 97% so this could be a relevant maximum as well."
         }
       }
     },
@@ -50,7 +47,7 @@
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
       "invalid_charger": "Invalid chager found",
       "unknown": "[%key:common::config_flow::error::unknown%]",
-      "outofscope": "Your number is out of the given range."
+      "outofscope": "The given number is out of range. Enter a number between "
     },
     "abort": {
       "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"

--- a/homeassistant/components/v2g_liberty/strings.json
+++ b/homeassistant/components/v2g_liberty/strings.json
@@ -34,6 +34,16 @@
         "data_description":{
           "batthigh": "Range between 60% and 100%. Some cars will never charge above 97% so this could be a relevant maximum as well."
         }
+      },
+      "battcap": {
+        "title": "Usable capacity for car battery",
+        "description": "This is the the maximum energy storage capacity of the car's battery that can be used for driving/charging/discharging. This often is lower than the advertised capacity. \n Find a reliable value on ↗ [EV Database]({ev_database_url}). \n\n **Battery health** \n If a battery get's older it usually degrades and cannot contain as much energy as when it was new. It's advised to take this into account here. Do this by looking for the State of Health (SoH) in the cars the menu's. \n *E.g:* \n The SoH is 11/12 and the original usable capacity was 56kWh use a value of 51kWh.",
+        "data": {
+          "battcap": "Usable capacity"
+        },
+        "data_description":{
+          "battcap": "Range between 60% and 100%. Some cars will never charge above 97% so this could be a relevant maximum as well."
+        }
       }
     },
     "error": {

--- a/homeassistant/components/v2g_liberty/strings.json
+++ b/homeassistant/components/v2g_liberty/strings.json
@@ -2,28 +2,37 @@
   "config": {
     "step": {
       "user": {
+        "title": "Charger",
         "menu_options": {
           "setup": "I have read the above text and wish to continue."
         },
-        "description": "Welcome to V2G Liberty! \n \n With V2G Liberty you can earn money, support the electrical grid and reduce your ecological footprint. \n \n Currently, this integration can only be used with a specific combination of electric car and charger. We hope to add more models later. \n \n Make sure the following apply to your situation: \n **- You have a Quasar 1 charger, with working bidirectional charging using the Wallbox app.** \n **- Your charger is connected to the same network as this Home Assistant installation.**"
+        "description": "Welcome to V2G Liberty! \n\n With V2G Liberty you can earn money, support the electrical grid and reduce your ecological footprint. \n\n Currently, this integration can only be used with a specific combination of electric car and charger. We hope to add more models later. \n\n Make sure the following apply to your situation: \n **- You have a Quasar 1 charger, with working bidirectional charging using the Wallbox app.** \n **- Your charger is connected to the same network as this Home Assistant installation.**"
       },
       "setup": {
-        "description": "Enter the Host and Port number for your charger.",
+        "description": "Enter the Host and Port number for your charger. This can be found in the Wallbox app: \n Settings > Connectivity > Ethernet",
         "data": {
           "host": "Host address",
           "port": "Port number"
         }
       },
-      "batterylow": {
-        "description": "Enter the Host and Port number for your charger.",
+      "battlow": {
+        "title": "Lower charge limit for car battery",
+        "description": "**Effects on automated charging** \n The automated schedule will never discharge below this value. \n If the car returns with and SoC below this value, the battery will directly be charged to this limit, before automated (scheduled) charging. \n\n **Effects on earnings** \n A high value results in always having a greater driving range available, even when not planned, but less capacity available for discharge and so lesser earnings. \n A lower value results in sometimes a smaller driving range available for un-planned drives but there is always more capacity for discharge and so more earnings. \n\n **Battery life** \n Some research suggests battery life is shorter if the SoC is below 15% for a longer period. \n\n **Odd car behaviour** \n In some cars the SoC every now and then skips a number, eg. from 21 to 19%, skipping 20%. This might result in toggling charging behaviour around this minimum SoC. If this happens try a value one higher or lower.",
         "data": {
-          "battlow": "Host address"
+          "battlow": "Minimum State of Charge %"
+        },
+        "data_description": {
+          "battlow": "Range between 10% and 30%."
         }
       },
-      "batteryhigh": {
-        "description": "Enter the Host and Port number for your charger.",
+      "batthigh": {
+        "title": "Upper charge limit for car battery",
+        "description": "**Effects on earnings** \n The schedule will use this limit for regular automated/scheduled charging. \n A low setting reduces schedule flexibility and so the capability to earn money and reduce emissions. \n\n When a calendar item is present, the schedule will ignore this limit and try to charge the battery to 100% or the provided battery target at the start of the calendar item. \n\n **Battery life** \n Some research suggests battery life is shorter if the SoC is above 85% for a longer period (days). \n\n **Odd car behaviour** \n In some cars the SoC drops 1% in short time when idle above a certain SoC (e.g. 95%). This results in a toggling charge behaviour, try setting this limit to a lower value.",
         "data": {
-          "batthigh": "Host address"
+          "batthigh": "Maximum State of Charge %"
+        },
+        "data_description":{
+          "batthigh": "Range between 60% and 100%. Some cars will never charge above 97% so this could be a relevant maximum as well."
         }
       }
     },
@@ -31,7 +40,7 @@
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
       "invalid_charger": "Invalid chager found",
       "unknown": "[%key:common::config_flow::error::unknown%]",
-      "outofscope": "Your number is out of scope."
+      "outofscope": "Your number is out of the given range."
     },
     "abort": {
       "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"

--- a/homeassistant/components/v2g_liberty/strings.json
+++ b/homeassistant/components/v2g_liberty/strings.json
@@ -47,7 +47,7 @@
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
       "invalid_charger": "Invalid chager found",
       "unknown": "[%key:common::config_flow::error::unknown%]",
-      "outofscope": "The given number is out of range. Enter a number between "
+      "outofrange": "The given number is out of range."
     },
     "abort": {
       "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"


### PR DESCRIPTION
Batteryflow
-
Added three new screens for the config flow about the battery:

- Charging minimum
On this screen, the user can define their minimum SoC.

- Charging maximum
On this screen, the user can define their maximum SoC.

- Charging capacity
On this screen, the user can define the capacity of their car battery.